### PR TITLE
[feat] : 냉장고 관련 api 구현 

### DIFF
--- a/src/main/java/capstone/recipable/domain/category/repository/CategoryRepository.java
+++ b/src/main/java/capstone/recipable/domain/category/repository/CategoryRepository.java
@@ -1,7 +1,11 @@
 package capstone.recipable.domain.category.repository;
 
 import capstone.recipable.domain.category.entity.Category;
+import capstone.recipable.domain.refrigerator.entity.Refrigerator;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface CategoryRepository extends JpaRepository<Category, Long> {
+    List<Category> findAllByRefrigeratorId(Refrigerator refrigerator);
 }

--- a/src/main/java/capstone/recipable/domain/category/repository/CategoryRepository.java
+++ b/src/main/java/capstone/recipable/domain/category/repository/CategoryRepository.java
@@ -5,7 +5,10 @@ import capstone.recipable.domain.refrigerator.entity.Refrigerator;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface CategoryRepository extends JpaRepository<Category, Long> {
     List<Category> findAllByRefrigeratorId(Refrigerator refrigerator);
+
+    Optional<Category> findByCategoryName(String newCategoryName);
 }

--- a/src/main/java/capstone/recipable/domain/expiration/entity/Expiration.java
+++ b/src/main/java/capstone/recipable/domain/expiration/entity/Expiration.java
@@ -29,4 +29,8 @@ public class Expiration {
                 .ingredientId(ingredientId)
                 .build();
     }
+
+    public void updateExpirationDate(LocalDate expireDate) {
+        this.expireDate = expireDate;
+    }
 }

--- a/src/main/java/capstone/recipable/domain/expiration/entity/Expiration.java
+++ b/src/main/java/capstone/recipable/domain/expiration/entity/Expiration.java
@@ -19,7 +19,7 @@ public class Expiration {
 
     private LocalDate expireDate;
 
-    @OneToOne
+    @OneToOne(cascade = CascadeType.ALL)
     private Ingredient ingredientId;
 
     public static Expiration of(Long id, LocalDate expireDate, Ingredient ingredientId) {

--- a/src/main/java/capstone/recipable/domain/expiration/repository/ExpirationRepository.java
+++ b/src/main/java/capstone/recipable/domain/expiration/repository/ExpirationRepository.java
@@ -1,7 +1,11 @@
 package capstone.recipable.domain.expiration.repository;
 
 import capstone.recipable.domain.expiration.entity.Expiration;
+import capstone.recipable.domain.ingredient.entity.Ingredient;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface ExpirationRepository extends JpaRepository<Expiration, Long> {
+    Optional<Expiration> findByIngredientId(Ingredient ingredient);
 }

--- a/src/main/java/capstone/recipable/domain/ingredient/controller/dto/request/UpdateIngredientRequest.java
+++ b/src/main/java/capstone/recipable/domain/ingredient/controller/dto/request/UpdateIngredientRequest.java
@@ -1,0 +1,16 @@
+package capstone.recipable.domain.ingredient.controller.dto.request;
+
+import capstone.recipable.domain.category.entity.Category;
+import capstone.recipable.domain.ingredient.entity.Ingredient;
+
+import java.time.LocalDate;
+
+public record UpdateIngredientRequest(
+        String ingredientImage,
+        String ingredientName,
+        String categoryName,
+        LocalDate expirationDay,
+        String memo
+) {
+
+}

--- a/src/main/java/capstone/recipable/domain/ingredient/controller/dto/response/IngredientDetailResponse.java
+++ b/src/main/java/capstone/recipable/domain/ingredient/controller/dto/response/IngredientDetailResponse.java
@@ -1,0 +1,14 @@
+package capstone.recipable.domain.ingredient.controller.dto.response;
+
+import java.time.LocalDate;
+
+public record IngredientDetailResponse(
+        String ingredientName,
+        String categoryName,
+        LocalDate expirationDay,
+        String memo
+) {
+    public static IngredientDetailResponse of(String ingredientName, String categoryName, LocalDate expirationDay, String memo) {
+        return new IngredientDetailResponse(ingredientName, categoryName, expirationDay, memo);
+    }
+}

--- a/src/main/java/capstone/recipable/domain/ingredient/entity/Ingredient.java
+++ b/src/main/java/capstone/recipable/domain/ingredient/entity/Ingredient.java
@@ -38,4 +38,11 @@ public class Ingredient {
                 .build();
     }
 
+    public void updateIngredientInfo(String ingredientName, String ingredientImage, String memo, Category category) {
+        this.ingredientName = ingredientName;
+        this.ingredientImage = ingredientImage;
+        this.memo = memo;
+        this.categoryId = category;
+    }
+
 }

--- a/src/main/java/capstone/recipable/domain/ingredient/entity/Ingredient.java
+++ b/src/main/java/capstone/recipable/domain/ingredient/entity/Ingredient.java
@@ -20,19 +20,21 @@ public class Ingredient {
 
     private String ingredientImage;
 
+    private String memo;
+
     @ManyToOne(fetch=FetchType.LAZY)
     private Category categoryId;
 
 //    @OneToOne
 //    private Expiration expirationId;
 
-    public static Ingredient of(Long id, String ingredientName, String ingredientImage, Category categoryId) {
+    public static Ingredient of(Long id, String ingredientName, String ingredientImage, String memo, Category categoryId) {
         return Ingredient.builder()
                 .id(id)
                 .ingredientName(ingredientName)
-                .categoryId(categoryId)
+                .memo(memo)
                 .ingredientImage(ingredientImage)
-//                .expirationId(expirationId)
+                .categoryId(categoryId)
                 .build();
     }
 

--- a/src/main/java/capstone/recipable/domain/ingredient/entity/Ingredient.java
+++ b/src/main/java/capstone/recipable/domain/ingredient/entity/Ingredient.java
@@ -18,18 +18,22 @@ public class Ingredient {
 
     private String ingredientName;
 
+    private String ingredientImage;
+
     @ManyToOne(fetch=FetchType.LAZY)
     private Category categoryId;
 
-    @OneToOne
-    private Expiration expirationId;
+//    @OneToOne
+//    private Expiration expirationId;
 
-    public static Ingredient of(Long id, String ingredientName, Category categoryId, Expiration expirationId) {
+    public static Ingredient of(Long id, String ingredientName, String ingredientImage, Category categoryId) {
         return Ingredient.builder()
                 .id(id)
                 .ingredientName(ingredientName)
                 .categoryId(categoryId)
-                .expirationId(expirationId)
+                .ingredientImage(ingredientImage)
+//                .expirationId(expirationId)
                 .build();
     }
+
 }

--- a/src/main/java/capstone/recipable/domain/ingredient/repository/IngredientRepository.java
+++ b/src/main/java/capstone/recipable/domain/ingredient/repository/IngredientRepository.java
@@ -1,7 +1,12 @@
 package capstone.recipable.domain.ingredient.repository;
 
+import capstone.recipable.domain.category.entity.Category;
 import capstone.recipable.domain.ingredient.entity.Ingredient;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+import java.util.Optional;
+
 public interface IngredientRepository extends JpaRepository<Ingredient, Long> {
+    List<Ingredient> findAllByCategoryId(Category category);
 }

--- a/src/main/java/capstone/recipable/domain/refrigerator/controller/RefrigeratorController.java
+++ b/src/main/java/capstone/recipable/domain/refrigerator/controller/RefrigeratorController.java
@@ -1,5 +1,6 @@
 package capstone.recipable.domain.refrigerator.controller;
 
+import capstone.recipable.domain.ingredient.controller.dto.request.UpdateIngredientRequest;
 import capstone.recipable.domain.ingredient.controller.dto.response.IngredientDetailResponse;
 import capstone.recipable.domain.refrigerator.dto.response.RefrigeratorListResponse;
 import capstone.recipable.domain.refrigerator.service.RefrigeratorService;
@@ -36,6 +37,19 @@ public class RefrigeratorController {
     @GetMapping("/{ingredientId}")
     public ResponseEntity<SuccessResponse<IngredientDetailResponse>> getIngredients(@PathVariable Long ingredientId) {
         IngredientDetailResponse ingredientDetail = refrigeratorService.getIngredient(ingredientId);
+        return SuccessResponse.of(ingredientDetail);
+    }
+
+    @Operation(summary = "냉장고 안 식재료 수정 api", description = """
+                        
+            사용자 냉장고 안에 있는 식재료를 수정 합니다.
+                        
+            """)
+    @PatchMapping("/{ingredientId}")
+    public ResponseEntity<SuccessResponse<IngredientDetailResponse>> updateIngredient(@PathVariable Long ingredientId,
+                                                                                      @RequestBody UpdateIngredientRequest updateIngredientRequest) {
+
+        IngredientDetailResponse ingredientDetail = refrigeratorService.updateIngredient(ingredientId, updateIngredientRequest);
         return SuccessResponse.of(ingredientDetail);
     }
 

--- a/src/main/java/capstone/recipable/domain/refrigerator/controller/RefrigeratorController.java
+++ b/src/main/java/capstone/recipable/domain/refrigerator/controller/RefrigeratorController.java
@@ -53,4 +53,16 @@ public class RefrigeratorController {
         return SuccessResponse.of(ingredientDetail);
     }
 
+    @Operation(summary = "냉장고 안 식재료 삭제 api", description = """
+                        
+            사용자 냉장고 안에 있는 식재료를 삭제 합니다.
+                        
+            """)
+    @DeleteMapping("/{ingredientId}")
+    public ResponseEntity<SuccessResponse<String>> updateIngredient(@PathVariable Long ingredientId) {
+
+        refrigeratorService.deleteIngredient(ingredientId);
+        return SuccessResponse.of("식재료가 성공적으로 삭제 되었습니다.");
+    }
+
 }

--- a/src/main/java/capstone/recipable/domain/refrigerator/controller/RefrigeratorController.java
+++ b/src/main/java/capstone/recipable/domain/refrigerator/controller/RefrigeratorController.java
@@ -1,5 +1,6 @@
 package capstone.recipable.domain.refrigerator.controller;
 
+import capstone.recipable.domain.ingredient.controller.dto.response.IngredientDetailResponse;
 import capstone.recipable.domain.refrigerator.dto.response.RefrigeratorListResponse;
 import capstone.recipable.domain.refrigerator.service.RefrigeratorService;
 import capstone.recipable.global.response.SuccessResponse;
@@ -8,6 +9,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -28,4 +30,16 @@ public class RefrigeratorController {
         RefrigeratorListResponse allIngredientsByRefrigerator = refrigeratorService.getAllIngredientsByRefrigerator();
         return SuccessResponse.of(allIngredientsByRefrigerator);
     }
+
+    @Operation(summary = "냉장고 안 식재료 상세 조회 api", description = """
+                        
+            사용자 냉장고 안에 있는 식재료를 상세 조회합니다.
+                        
+            """)
+    @GetMapping("/{ingredientId}")
+    public ResponseEntity<SuccessResponse<IngredientDetailResponse>> getAllIngredientsByRefrigerator(@PathVariable Long ingredientId) {
+        IngredientDetailResponse ingredientDetail = refrigeratorService.getIngredient(ingredientId);
+        return SuccessResponse.of(ingredientDetail);
+    }
+
 }

--- a/src/main/java/capstone/recipable/domain/refrigerator/controller/RefrigeratorController.java
+++ b/src/main/java/capstone/recipable/domain/refrigerator/controller/RefrigeratorController.java
@@ -1,0 +1,31 @@
+package capstone.recipable.domain.refrigerator.controller;
+
+import capstone.recipable.domain.refrigerator.dto.response.RefrigeratorListResponse;
+import capstone.recipable.domain.refrigerator.service.RefrigeratorService;
+import capstone.recipable.global.response.SuccessResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/refrigerators")
+@Tag(name = "refrigerator", description = "냉장고 관련 api")
+public class RefrigeratorController {
+    private final RefrigeratorService refrigeratorService;
+
+    @Operation(summary = "냉장고 안 식재료 전체 조회 api", description = """
+            
+            사용자 냉장고 안에 있는 식재료를 전체 조회합니다.
+            
+            """)
+    @GetMapping
+    public ResponseEntity<SuccessResponse<RefrigeratorListResponse>> getAllIngredientsByRefrigerator() {
+        RefrigeratorListResponse allIngredientsByRefrigerator = refrigeratorService.getAllIngredientsByRefrigerator();
+        return SuccessResponse.of(allIngredientsByRefrigerator);
+    }
+}

--- a/src/main/java/capstone/recipable/domain/refrigerator/controller/RefrigeratorController.java
+++ b/src/main/java/capstone/recipable/domain/refrigerator/controller/RefrigeratorController.java
@@ -8,10 +8,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -37,7 +34,7 @@ public class RefrigeratorController {
                         
             """)
     @GetMapping("/{ingredientId}")
-    public ResponseEntity<SuccessResponse<IngredientDetailResponse>> getAllIngredientsByRefrigerator(@PathVariable Long ingredientId) {
+    public ResponseEntity<SuccessResponse<IngredientDetailResponse>> getIngredients(@PathVariable Long ingredientId) {
         IngredientDetailResponse ingredientDetail = refrigeratorService.getIngredient(ingredientId);
         return SuccessResponse.of(ingredientDetail);
     }

--- a/src/main/java/capstone/recipable/domain/refrigerator/dto/response/RefrigeratorDetailResponse.java
+++ b/src/main/java/capstone/recipable/domain/refrigerator/dto/response/RefrigeratorDetailResponse.java
@@ -1,11 +1,12 @@
 package capstone.recipable.domain.refrigerator.dto.response;
 
 public record RefrigeratorDetailResponse(
+        Long ingredientId,
         String ingredientName,
         Long expiredRemaining,
         String ingredientImage
 ) {
-    public static RefrigeratorDetailResponse of(String ingredientName, Long expiredRemaining,String ingredientImage) {
-        return new RefrigeratorDetailResponse(ingredientName, expiredRemaining, ingredientImage);
+    public static RefrigeratorDetailResponse of(Long ingredientId,String ingredientName, Long expiredRemaining,String ingredientImage) {
+        return new RefrigeratorDetailResponse(ingredientId, ingredientName, expiredRemaining, ingredientImage);
     }
 }

--- a/src/main/java/capstone/recipable/domain/refrigerator/dto/response/RefrigeratorDetailResponse.java
+++ b/src/main/java/capstone/recipable/domain/refrigerator/dto/response/RefrigeratorDetailResponse.java
@@ -1,8 +1,5 @@
 package capstone.recipable.domain.refrigerator.dto.response;
 
-import lombok.Builder;
-
-@Builder
 public record RefrigeratorDetailResponse(
         String ingredientName,
         Long expiredRemaining,

--- a/src/main/java/capstone/recipable/domain/refrigerator/dto/response/RefrigeratorDetailResponse.java
+++ b/src/main/java/capstone/recipable/domain/refrigerator/dto/response/RefrigeratorDetailResponse.java
@@ -1,0 +1,14 @@
+package capstone.recipable.domain.refrigerator.dto.response;
+
+import lombok.Builder;
+
+@Builder
+public record RefrigeratorDetailResponse(
+        String ingredientName,
+        Long expiredRemaining,
+        String ingredientImage
+) {
+    public static RefrigeratorDetailResponse of(String ingredientName, Long expiredRemaining,String ingredientImage) {
+        return new RefrigeratorDetailResponse(ingredientName, expiredRemaining, ingredientImage);
+    }
+}

--- a/src/main/java/capstone/recipable/domain/refrigerator/dto/response/RefrigeratorListResponse.java
+++ b/src/main/java/capstone/recipable/domain/refrigerator/dto/response/RefrigeratorListResponse.java
@@ -1,0 +1,11 @@
+package capstone.recipable.domain.refrigerator.dto.response;
+
+import java.util.List;
+
+public record RefrigeratorListResponse(
+        List<RefrigeratorResponse> refrigeratorList
+) {
+    public static RefrigeratorListResponse of(List<RefrigeratorResponse> refrigeratorResponseList) {
+        return new RefrigeratorListResponse(refrigeratorResponseList);
+    }
+}

--- a/src/main/java/capstone/recipable/domain/refrigerator/dto/response/RefrigeratorResponse.java
+++ b/src/main/java/capstone/recipable/domain/refrigerator/dto/response/RefrigeratorResponse.java
@@ -1,0 +1,16 @@
+package capstone.recipable.domain.refrigerator.dto.response;
+
+import capstone.recipable.domain.refrigerator.dto.response.RefrigeratorDetailResponse;
+
+import java.util.List;
+
+public record RefrigeratorResponse(
+        String categoryName,
+        String detailContent,
+        List<RefrigeratorDetailResponse> refrigeratorDetailList
+
+) {
+    public static RefrigeratorResponse of(String categoryName, String detailContent, List<RefrigeratorDetailResponse> refrigeratorDetailResponseList) {
+        return new RefrigeratorResponse(categoryName, detailContent, refrigeratorDetailResponseList);
+    }
+}

--- a/src/main/java/capstone/recipable/domain/refrigerator/dto/response/RefrigeratorResponse.java
+++ b/src/main/java/capstone/recipable/domain/refrigerator/dto/response/RefrigeratorResponse.java
@@ -1,7 +1,5 @@
 package capstone.recipable.domain.refrigerator.dto.response;
 
-import capstone.recipable.domain.refrigerator.dto.response.RefrigeratorDetailResponse;
-
 import java.util.List;
 
 public record RefrigeratorResponse(

--- a/src/main/java/capstone/recipable/domain/refrigerator/repository/RefrigeratorRepository.java
+++ b/src/main/java/capstone/recipable/domain/refrigerator/repository/RefrigeratorRepository.java
@@ -1,7 +1,11 @@
 package capstone.recipable.domain.refrigerator.repository;
 
 import capstone.recipable.domain.refrigerator.entity.Refrigerator;
+import capstone.recipable.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface RefrigeratorRepository extends JpaRepository<Refrigerator, Long> {
+    Optional<Refrigerator> findByUserId(User user);
 }

--- a/src/main/java/capstone/recipable/domain/refrigerator/service/RefrigeratorService.java
+++ b/src/main/java/capstone/recipable/domain/refrigerator/service/RefrigeratorService.java
@@ -1,0 +1,69 @@
+package capstone.recipable.domain.refrigerator.service;
+
+import capstone.recipable.domain.auth.jwt.SecurityContextProvider;
+import capstone.recipable.domain.category.entity.Category;
+import capstone.recipable.domain.category.repository.CategoryRepository;
+import capstone.recipable.domain.expiration.entity.Expiration;
+import capstone.recipable.domain.expiration.repository.ExpirationRepository;
+import capstone.recipable.domain.ingredient.entity.Ingredient;
+import capstone.recipable.domain.ingredient.repository.IngredientRepository;
+import capstone.recipable.domain.refrigerator.dto.response.RefrigeratorDetailResponse;
+import capstone.recipable.domain.refrigerator.dto.response.RefrigeratorListResponse;
+import capstone.recipable.domain.refrigerator.dto.response.RefrigeratorResponse;
+import capstone.recipable.domain.refrigerator.entity.Refrigerator;
+import capstone.recipable.domain.refrigerator.repository.RefrigeratorRepository;
+import capstone.recipable.domain.user.entity.User;
+import capstone.recipable.domain.user.repository.UserRepository;
+import capstone.recipable.global.error.ApplicationException;
+import capstone.recipable.global.error.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.cglib.core.Local;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.Period;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+
+@RequiredArgsConstructor
+@Service
+@Transactional(readOnly = true)
+@Slf4j
+public class RefrigeratorService {
+    private final UserRepository userRepository;
+    private final RefrigeratorRepository refrigeratorRepository;
+    private final CategoryRepository categoryRepository;
+    private final IngredientRepository ingredientRepository;
+    private final ExpirationRepository expirationRepository;
+
+
+    public RefrigeratorListResponse getAllIngredientsByRefrigerator() {
+        User user = userRepository.findById(SecurityContextProvider.getAuthenticatedUserId())
+                .orElseThrow(() -> new ApplicationException(ErrorCode.USER_NOT_FOUND));
+
+        Refrigerator refrigerator = refrigeratorRepository.findByUserId(user)
+                .orElseThrow(() -> new ApplicationException(ErrorCode.REFRIGERATOR_NOT_FOUND));
+
+        List<Category> allCategoryByRefrigerator = categoryRepository.findAllByRefrigeratorId(refrigerator);
+        List<RefrigeratorResponse> refrigeratorResponses = allCategoryByRefrigerator.stream()
+                .map(category -> {
+                    List<Ingredient> ingredients = ingredientRepository.findAllByCategoryId(category);
+
+                    List<RefrigeratorDetailResponse> refrigeratorDetails = ingredients.stream()
+                            .map(ingredient -> {
+                                Expiration expiration = expirationRepository.findByIngredientId(ingredient)
+                                        .orElseThrow(() -> new ApplicationException(ErrorCode.EXPIRATION_NOT_FOUND));
+
+                                Long remainingExpiration = ChronoUnit.DAYS.between(LocalDate.now(), expiration.getExpireDate());
+                                RefrigeratorDetailResponse refrigeratorDetail = RefrigeratorDetailResponse.of(ingredient.getIngredientName(), remainingExpiration, ingredient.getIngredientImage());
+
+                                return refrigeratorDetail;
+                            }).toList();
+                    return RefrigeratorResponse.of(category.getCategoryName(), category.getDetails(), refrigeratorDetails);
+                }).toList();
+
+        return RefrigeratorListResponse.of(refrigeratorResponses);
+    }
+}

--- a/src/main/java/capstone/recipable/domain/refrigerator/service/RefrigeratorService.java
+++ b/src/main/java/capstone/recipable/domain/refrigerator/service/RefrigeratorService.java
@@ -96,4 +96,13 @@ public class RefrigeratorService {
         return IngredientDetailResponse.of(ingredient.getIngredientName(), ingredient.getCategoryId().getCategoryName(),
                 expiration.getExpireDate(), ingredient.getMemo());
     }
+
+    @Transactional
+    public void deleteIngredient(Long ingredientId) {
+        Ingredient ingredient = ingredientRepository.findById(ingredientId)
+                .orElseThrow(() -> new ApplicationException(ErrorCode.INGREDIENT_NOT_FOUND));
+        expirationRepository.delete(
+                expirationRepository.findByIngredientId(ingredient).orElseThrow(() -> new ApplicationException(ErrorCode.EXPIRATION_NOT_FOUND))
+        );
+    }
 }

--- a/src/main/java/capstone/recipable/domain/refrigerator/service/RefrigeratorService.java
+++ b/src/main/java/capstone/recipable/domain/refrigerator/service/RefrigeratorService.java
@@ -5,6 +5,7 @@ import capstone.recipable.domain.category.entity.Category;
 import capstone.recipable.domain.category.repository.CategoryRepository;
 import capstone.recipable.domain.expiration.entity.Expiration;
 import capstone.recipable.domain.expiration.repository.ExpirationRepository;
+import capstone.recipable.domain.ingredient.controller.dto.response.IngredientDetailResponse;
 import capstone.recipable.domain.ingredient.entity.Ingredient;
 import capstone.recipable.domain.ingredient.repository.IngredientRepository;
 import capstone.recipable.domain.refrigerator.dto.response.RefrigeratorDetailResponse;
@@ -18,12 +19,10 @@ import capstone.recipable.global.error.ApplicationException;
 import capstone.recipable.global.error.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.cglib.core.Local;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
-import java.time.Period;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
 
@@ -65,5 +64,16 @@ public class RefrigeratorService {
                 }).toList();
 
         return RefrigeratorListResponse.of(refrigeratorResponses);
+    }
+
+    public IngredientDetailResponse getIngredient(Long ingredientId) {
+        Ingredient ingredient = ingredientRepository.findById(ingredientId)
+                .orElseThrow(() -> new ApplicationException(ErrorCode.INGREDIENT_NOT_FOUND));
+
+        Expiration expiration = expirationRepository.findByIngredientId(ingredient)
+                .orElseThrow(() -> new ApplicationException(ErrorCode.EXPIRATION_NOT_FOUND));
+
+        return IngredientDetailResponse.of(ingredient.getIngredientName(), ingredient.getCategoryId().getCategoryName(),
+                expiration.getExpireDate(), ingredient.getMemo());
     }
 }

--- a/src/main/java/capstone/recipable/domain/refrigerator/service/RefrigeratorService.java
+++ b/src/main/java/capstone/recipable/domain/refrigerator/service/RefrigeratorService.java
@@ -57,7 +57,7 @@ public class RefrigeratorService {
                                         .orElseThrow(() -> new ApplicationException(ErrorCode.EXPIRATION_NOT_FOUND));
 
                                 Long remainingExpiration = ChronoUnit.DAYS.between(LocalDate.now(), expiration.getExpireDate());
-                                RefrigeratorDetailResponse refrigeratorDetail = RefrigeratorDetailResponse.of(ingredient.getIngredientName(), remainingExpiration, ingredient.getIngredientImage());
+                                RefrigeratorDetailResponse refrigeratorDetail = RefrigeratorDetailResponse.of(ingredient.getId(), ingredient.getIngredientName(), remainingExpiration, ingredient.getIngredientImage());
 
                                 return refrigeratorDetail;
                             }).toList();

--- a/src/main/java/capstone/recipable/domain/refrigerator/service/RefrigeratorService.java
+++ b/src/main/java/capstone/recipable/domain/refrigerator/service/RefrigeratorService.java
@@ -5,6 +5,7 @@ import capstone.recipable.domain.category.entity.Category;
 import capstone.recipable.domain.category.repository.CategoryRepository;
 import capstone.recipable.domain.expiration.entity.Expiration;
 import capstone.recipable.domain.expiration.repository.ExpirationRepository;
+import capstone.recipable.domain.ingredient.controller.dto.request.UpdateIngredientRequest;
 import capstone.recipable.domain.ingredient.controller.dto.response.IngredientDetailResponse;
 import capstone.recipable.domain.ingredient.entity.Ingredient;
 import capstone.recipable.domain.ingredient.repository.IngredientRepository;
@@ -72,6 +73,25 @@ public class RefrigeratorService {
 
         Expiration expiration = expirationRepository.findByIngredientId(ingredient)
                 .orElseThrow(() -> new ApplicationException(ErrorCode.EXPIRATION_NOT_FOUND));
+
+        return IngredientDetailResponse.of(ingredient.getIngredientName(), ingredient.getCategoryId().getCategoryName(),
+                expiration.getExpireDate(), ingredient.getMemo());
+    }
+
+    @Transactional
+    public IngredientDetailResponse updateIngredient(Long ingredientId, UpdateIngredientRequest updateIngredientRequest) {
+        Ingredient ingredient = ingredientRepository.findById(ingredientId)
+                .orElseThrow(() -> new ApplicationException(ErrorCode.INGREDIENT_NOT_FOUND));
+
+        Expiration expiration = expirationRepository.findByIngredientId(ingredient)
+                .orElseThrow(() -> new ApplicationException(ErrorCode.EXPIRATION_NOT_FOUND));
+
+        String requestedCategoryName = updateIngredientRequest.categoryName();
+        Category category = categoryRepository.findByCategoryName(requestedCategoryName)
+                .orElseThrow(() -> new ApplicationException(ErrorCode.CATEGORY_NOT_FOUND));
+
+        ingredient.updateIngredientInfo(updateIngredientRequest.ingredientName(), updateIngredientRequest.ingredientImage(), updateIngredientRequest.memo(), category);
+        expiration.updateExpirationDate(updateIngredientRequest.expirationDay());
 
         return IngredientDetailResponse.of(ingredient.getIngredientName(), ingredient.getCategoryId().getCategoryName(),
                 expiration.getExpireDate(), ingredient.getMemo());

--- a/src/main/java/capstone/recipable/global/error/ErrorCode.java
+++ b/src/main/java/capstone/recipable/global/error/ErrorCode.java
@@ -37,7 +37,33 @@ public enum ErrorCode {
      *  500 INTERNAL SERVER ERROR
      */
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류입니다."),
-    FILE_UPLOAD_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "S3 이미지 업로드에 실패");
+    FILE_UPLOAD_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "S3 이미지 업로드에 실패"),
+
+    /**
+     * User 관련 에러
+     */
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND,"사용자를 찾을 수 없습니다."),
+
+    /**
+     * Refrigerator 관련 ERROR
+     */
+    REFRIGERATOR_NOT_FOUND(HttpStatus.NOT_FOUND,"냉장고를 찾을 수 없습니다."),
+
+    /**
+     * Ingredient 관련 ERROR
+     */
+    INGREDIENT_NOT_FOUND(HttpStatus.NOT_FOUND,"식재료를 찾을 수 없습니다."),
+
+    /**
+     * EXPIRATION 관련 ERROR
+     */
+    EXPIRATION_NOT_FOUND(HttpStatus.NOT_FOUND,"해당 식재료의 유효기간을 찾을 수 없습니다."),
+
+    /**
+     * CATEGORY 관련 ERROR
+     */
+    CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND,"카태고리를 찾을 수 없습니다.");
+
 
     private final HttpStatus status;
     private final String message;


### PR DESCRIPTION
### ✏️ 관련 이슈
본인이 작업한 내용이 어떤 Issue Number와 관련이 있는지만 작성해주세요

- #33 


---

### 📝 작업 내용
이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- 냉장고 안 식재료 전체 조회 api 구현
- 냉장고 안 식재료 상세 조회 api 구현
- 냉장고 안 식재료 수정 api 구현(이미지 로직 수정)
- 냉장고 안 식재료 삭제 api 구현
---

### 🎸 기타 사항 or 추가 코멘트
현재 식재료 이미지 null 인 상태, 각 식재료의 default 이미지는 네이버 검색 api를 통해 불러온 이미지로 한 후 
사용자가 식재료를 수정할 때 사용자가 선택한 이미지로 수정할 수 있게 할 예정

다음 작업 : s3 setting 및 이미지 관련 로직 수정


